### PR TITLE
Ignore UTF-8 errors in RPC messages

### DIFF
--- a/pynvim_pp/rpc.py
+++ b/pynvim_pp/rpc.py
@@ -43,6 +43,12 @@ from .types import PARENT, Chan, Ext, ExtData, Method, NvimError, RPCallable, RP
 from .window import Window
 
 
+_IS_PYTHON3 = version_info >= (3, 0)
+if _IS_PYTHON3:
+    _UNICODE_ERRORS_DEFAULT = 'surrogateescape'
+else:
+    _UNICODE_ERRORS_DEFAULT = 'ignore'
+
 @unique
 class MsgType(Enum):
     req = 0
@@ -125,7 +131,7 @@ async def _connect(
     rx: Callable[[AsyncIterator[Any]], Awaitable[None]],
     hooker: _Hooker,
 ) -> None:
-    packer, unpacker = Packer(default=_pack), Unpacker(ext_hook=hooker.ext_hook)
+    packer, unpacker = Packer(default=_pack, unicode_errors=_UNICODE_ERRORS_DEFAULT), Unpacker(ext_hook=hooker.ext_hook, unicode_errors=_UNICODE_ERRORS_DEFAULT)
 
     async def send() -> None:
         async for frame in tx:


### PR DESCRIPTION
I've been bitten by an issue with COQ crashing when I by mistake paste raw bytes into a Neovim buffer.

This is due to the fact that the `nvim_buf_lines_event` message sent out by Neovim to clients encodes line data as (C) strings, which the Python clients try to unpack as Python (UTF-8) strings, which may throw a UnicodeDecodeError when fed random bytes:

```python
Traceback (most recent call last):                                                                                                                                                                                                           
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/coq/__main__.py", line 173, in <module>
    arun(main())
  File "/usr/lib/python3.11/asyncio/runners.py", line 190, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/asyncio/base_events.py", line 653, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/coq/__main__.py", line 171, in main
    await init(args.socket, ppid=args.ppid)
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/coq/client.py", line 70, in init
    async with conn(socket, default=_default) as client:
  File "/usr/lib/python3.11/contextlib.py", line 211, in __aexit__
    await anext(self.gen)
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.11/site-packages/pynvim_pp/nvim.py", line 249, in conn
    async with client(socket, default=default) as rpc:
  File "/usr/lib/python3.11/contextlib.py", line 211, in __aexit__
    await anext(self.gen)
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.11/site-packages/pynvim_pp/rpc.py", line 254, in client
    await conn
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.11/site-packages/pynvim_pp/rpc.py", line 144, in _connect
    await gather(rx(recv()), send())
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.11/site-packages/pynvim_pp/rpc.py", line 189, in rx
    async for frame in rx:
  File "/home/internet/.local/share/nvim/site/pack/packer/start/coq_nvim/.vars/runtime/lib/python3.11/site-packages/pynvim_pp/rpc.py", line 141, in recv
    for frame in unpacker:
  File "msgpack/_unpacker.pyx", line 540, in msgpack._cmsgpack.Unpacker.__next__
  File "msgpack/_unpacker.pyx", line 463, in msgpack._cmsgpack.Unpacker._unpack
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xd8 in position 1: invalid continuation byte
```

This issue doesn't occur with a simple Python client using pynvim:

```python
>>> from pynvim import attach
>>> n = attach('socket', path='/tmp/nvim')
>>> n.request('nvim_buf_attach', 1, False, {})
True
>>> while True: m=n.next_message(); print(m);
... 
['notification', 'nvim_buf_changedtick_event', [<Buffer(handle=1)>, 13]]
['notification', 'nvim_buf_lines_event', [<Buffer(handle=1)>, 14, 2, 3, ["\udc81\udc80\x01\udcbb\udce5\udc8bf\x02\udcf3\udc96Z\udc83&\udcb2,Ѝ\udc9b\udc93$\r\udc8ds\udcee\x03Y\udc91}\udcf6\udce6\udce5,\x11@4h0\udc90y',\udcb1\u0605\udca0\x0e\udcc1*+\x06\udc98\x03\udce4.\udca5$\udcb4\x10\udce5\x16Ȱ\udc85\udc96s\udcaf\udc92\udca2\udcd3XiF\udc82\udceb5\udca2\udcbf0\udc9a\udce0\x1a\x18\udc8f4\udcf8\udca8\udca7~\udcee\x03\x03rZV\x04\udce5\udce3\udce9\udc89δ貇iC\x1eK\udc9c\udca2\r?\x0e\\v:\udc8a.\udcf4\x13\udcf0\rTԸG\udcbe^", "\udcaf\udcdb\x07&&\udcabٜl\udc91\udcdfxd\udcbcl\udcd9\udce8N\udcd9F\udcfaэ(\udc9a)\x17@\udc97\udcda\x1c\udcaa\udcba\udcee\udc96\x19\udc879bYN!\udc8f\udca3ڳ\x07b\udce1O\udcfd\udce0\udc8a\udcefA\udccf\x1c\t\udcbce\udcb3\udcf3Q\udc9d\udcbbS,#%\udca3-\udc93\x17q\udcb7\udc89\x17\udcae2@\udcf7\udcceY\x08\udc92W\udcf3\udc88R\udc87\udcdcO'\udcber;\udcb5V\udcf3w\udccf䋞\x17-y\x17(-", 'I\udc85N\udc82BG\udc98P\udce9|4\\H\udcaf\udc9f\udcc9'], False]]
```

It turns out that when creating the msgpack Packer & Unpacker, pynvim sets the `unicode_errors` argument so that msgpack handles those decode errors itself: https://github.com/neovim/pynvim/blob/master/pynvim/msgpack_rpc/msgpack_stream.py#L23

This PR passes this argument to the msgpack Packer & Unpacker constructors, so that pynvim_pp no longer chokes on invalid UTF-8 in buffer data.
